### PR TITLE
Added check for undefined when indexing into target on construct

### DIFF
--- a/src/pyjamas.js
+++ b/src/pyjamas.js
@@ -459,7 +459,7 @@ var Pyjamas = (function () {
             // For each defined value we need to decode it
             // and recursively apply  the corresponding constructor
             for (key in pjs.defines) {
-                if (pjs.defines.hasOwnProperty(key)) {
+                if (pjs.defines.hasOwnProperty(key) && target[key] !== undefined) {
                     instance[key] = decode(pjs.defines[key], target[key]);
                 }
             }

--- a/test/specs/construct.spec.js
+++ b/test/specs/construct.spec.js
@@ -89,6 +89,15 @@ describe('Pyjamas.construct', function () {
         expect(instance.name).toEqual('hello goodbye tom');
         expect(Pyjamas.manifest(instance).version).toEqual('1.2.3');
     });
+    
+    it('Processes missing registered children', function(){
+        // This intentionally does not include the 'a' attribute of MyClassA
+        var instance = Pyjamas.construct(MyClassB, { name: 'test' });
+        expect(instance.name).toBe('test');
+        expect(instance.a).not.toBe(undefined);
+        expect(instance.a.value).toBe(0);
+        expect(instance.b).toBe(1);
+    });
 
 });
 


### PR DESCRIPTION
This addresses #54.

Now when you do not include a registered subchild in your json, it will not error when trying to index into that child.